### PR TITLE
Potential fix for code scanning alert no. 21: XML internal entity expansion

### DIFF
--- a/Season-2/Level-3/package.json
+++ b/Season-2/Level-3/package.json
@@ -16,7 +16,8 @@
       "libxmljs": "^1.0.9",
       "multer": "^2.0.2",
       "path": "^0.12.7",
-      "shell-quote": "^1.8.3"
+      "shell-quote": "^1.8.3",
+      "sax": "^1.4.1"
     },
     "devDependencies": {
       "chai": "^4.3.8",


### PR DESCRIPTION
Potential fix for [https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/21](https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/21)

To fix the problem, replace the use of `libxmljs.parseXml` for parsing untrusted XML input with a SAX-style parser such as the `sax` package, which does not expand internal entities and only expands standard XML entities. This change should be made in the `/ufo` endpoint where XML is parsed (lines 31–62). The new code should use `sax.parser` to parse the XML string, extract the text content from element nodes, and build the response as before. You will need to add an import for `sax` at the top of the file. The rest of the code (JSON handling, file upload endpoint, etc.) can remain unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
