### PR TITLE
Potential fix for code scanning alert no. 23: Type confusion through parameter tampering

### DIFF
--- a/Season-2/Level-3/solution.js
+++ b/Season-2/Level-3/solution.js
@@ -52,8 +52,8 @@ app.post("/ufo", (req, res) => {
 
       // Check for suspicious SYSTEM entity or .admin references in raw XML
       if (
-        req.body.includes('SYSTEM "') &&
-        req.body.includes(".admin")
+        typeof req.body !== 'string' ||
+        (req.body.includes('SYSTEM "') && req.body.includes(".admin"))
       ) {
         // Removed the code to execute commands within the .admin file on the server
         res.status(400).send("Invalid XML");         


### PR DESCRIPTION
Potential fix for [https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/23](https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/23)

To fix the problem, we should ensure that `req.body` is a string before calling `.includes()` on it. This can be done by adding a type check using `typeof req.body === 'string'` before performing the suspicious substring checks. If `req.body` is not a string, the request should be rejected as invalid. The best place to do this is in the XML handling branch, just before the check for suspicious content. Only proceed with the `.includes()` checks if the type is correct. This change should be made in the `/ufo` POST handler, specifically in the `"application/xml"` branch, at or just before line 54.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
