### PR TITLE
Potential fix for code scanning alert no. 13: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/Season-1/Level-5/solution.py
+++ b/Season-1/Level-5/solution.py
@@ -22,15 +22,15 @@ class SHA256_hasher:
 
     # produces the password hash by combining password + salt because hashing
     def password_hash(self, password, salt):
-        password = binascii.hexlify(hashlib.sha256(password.encode()).digest())
-        password_hash = bcrypt.hashpw(password, salt)
+        password_bytes = password.encode('utf-8')
+        password_hash = bcrypt.hashpw(password_bytes, salt)
         return password_hash.decode('ascii')
 
     # verifies that the hashed password reverses to the plain text version on verification
     def password_verification(self, password, password_hash):
-        password = binascii.hexlify(hashlib.sha256(password.encode()).digest())
+        password_bytes = password.encode('utf-8')
         password_hash = password_hash.encode('ascii')
-        return bcrypt.checkpw(password, password_hash)
+        return bcrypt.checkpw(password_bytes, password_hash)
 
 # a collection of sensitive secrets necessary for the software to operate
 PRIVATE_KEY = os.environ.get('PRIVATE_KEY')


### PR DESCRIPTION
Potential fix for [https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/13](https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/13)

To fix the problem, we should remove the use of SHA-256 for hashing the password before passing it to bcrypt. Instead, the password should be encoded directly (as bytes) and passed to `bcrypt.hashpw` and `bcrypt.checkpw`, which are designed to securely hash passwords and handle salts internally. This change should be made in both the `password_hash` and `password_verification` methods of the `SHA256_hasher` class in `Season-1/Level-5/solution.py`. No additional imports or dependencies are required, as bcrypt is already imported and used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
