### PR TITLE
Potential fix for code scanning alert no. 10: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/Season-1/Level-5/code.py
+++ b/Season-1/Level-5/code.py
@@ -28,15 +28,15 @@ class SHA256_hasher:
 
     # produces the password hash by combining password + salt because hashing
     def password_hash(self, password, salt):
-        password = binascii.hexlify(hashlib.sha256(password.encode()).digest())
-        password_hash = bcrypt.hashpw(password, salt)
+        password_bytes = password.encode()
+        password_hash = bcrypt.hashpw(password_bytes, salt)
         return password_hash.decode('ascii')
 
     # verifies that the hashed password reverses to the plain text version on verification
     def password_verification(self, password, password_hash):
-        password = binascii.hexlify(hashlib.sha256(password.encode()).digest())
-        password_hash = password_hash.encode('ascii')
-        return bcrypt.checkpw(password, password_hash)
+        password_bytes = password.encode()
+        password_hash_bytes = password_hash.encode('ascii')
+        return bcrypt.checkpw(password_bytes, password_hash_bytes)
 
 class MD5_hasher:
 


### PR DESCRIPTION
Potential fix for [https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/10](https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/10)

To fix the problem, remove the use of SHA-256 for pre-hashing passwords in the `SHA256_hasher` class. Instead, pass the raw password bytes directly to bcrypt for both hashing and verification, as is done in the `MD5_hasher` class. This change should be made in the `password_hash` and `password_verification` methods of the `SHA256_hasher` class (lines 31, 32, 37, 39). No additional imports are needed, as bcrypt is already imported. The functionality of the code will remain the same, but the password hashing will be more secure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
