### PR TITLE
Potential fix for code scanning alert no. 8: Uncontrolled data used in path expression

### DIFF
--- a/Season-1/Level-3/code.py
+++ b/Season-1/Level-3/code.py
@@ -48,8 +48,14 @@ class TaxPayer:
         if not path:
             raise Exception("Error: Tax form is required for all users")
 
-        with open(path, 'rb') as form:
+        # Defend against path traversal attacks
+        base_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tax_forms")
+        fullpath = os.path.normpath(os.path.join(base_dir, path))
+        if not fullpath.startswith(base_dir):
+            raise Exception("Error: Invalid tax form path")
+
+        with open(fullpath, 'rb') as form:
             tax_data = bytearray(form.read())
 
         # assume that tax data is returned on screen after this
-        return path
+        return fullpath


### PR DESCRIPTION
Potential fix for [https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/8](https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/8)

To fix the problem, we need to ensure that the file path used in `get_tax_form_attachment` is safe and does not allow path traversal or access to files outside a designated directory. The best way to do this is to define a safe base directory (e.g., a folder where tax form attachments are stored), normalize the user-supplied path, and check that the resulting path is within the base directory. This is similar to the approach already used in `get_prof_picture`.

**Steps:**
- Define a `base_dir` for tax form attachments (e.g., a subdirectory of the current file's directory).
- Use `os.path.normpath` and `os.path.join` to combine the base directory and the user-supplied path.
- Check that the normalized path starts with the base directory path.
- Only open the file if the check passes; otherwise, raise an exception.

**Required changes:**
- Edit the `get_tax_form_attachment` method in `Season-1/Level-3/code.py` to implement the above logic.
- No new imports are needed, as `os` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
