### PR TITLE
Potential fix for code scanning alert no. 7: Uncontrolled data used in path expression

### DIFF
--- a/Season-1/Level-3/code.py
+++ b/Season-1/Level-3/code.py
@@ -27,13 +27,11 @@ class TaxPayer:
         if not path:
             pass
 
-        # defends against path traversal attacks
-        if path.startswith('/') or path.startswith('..'):
-            return None
-
-        # builds path
-        base_dir = os.path.dirname(os.path.abspath(__file__))
+        # Defend against path traversal attacks
+        base_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "profile_pictures")
         prof_picture_path = os.path.normpath(os.path.join(base_dir, path))
+        if not prof_picture_path.startswith(base_dir):
+            return None
 
         with open(prof_picture_path, 'rb') as pic:
             picture = bytearray(pic.read())


### PR DESCRIPTION
Potential fix for [https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/7](https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/7)

To fix the problem, we need to ensure that the constructed file path for the profile picture is contained within a safe root directory. This involves normalizing the path and then checking that the normalized path starts with the base directory. The best way to do this is to follow the pattern used in `get_tax_form_attachment`:  
- Set a dedicated subdirectory (e.g., `profile_pictures`) within the base directory for profile pictures.
- Normalize the joined path.
- Check that the normalized path starts with the base directory for profile pictures.
- Only proceed to open the file if the check passes.

The changes should be made in the `get_prof_picture` method (lines 25–42) of `Season-1/Level-3/code.py`. No new imports are needed, as `os` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
