### PR TITLE
Potential fix for code scanning alert no. 30: SQL query built from user-controlled sources

### DIFF
--- a/Season-1/Level-4/code.py
+++ b/Season-1/Level-4/code.py
@@ -248,7 +248,7 @@ class DB_CRUD_ops(object):
                 match = re.search(r"where\s+symbol\s*=\s*'([^']+)'", lowered)
                 if match:
                     symbol = match.group(1)
-                    safe_query = re.sub(r"where\s+symbol\s*=\s*'[^']+'", "where symbol = ?", query, flags=re.IGNORECASE)
+                    safe_query = "SELECT * FROM stocks WHERE symbol = ?"
                     cur.execute(safe_query, (symbol,))
                 else:
                     # Only allow queries that match a safe SELECT pattern


### PR DESCRIPTION
Potential fix for [https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/30](https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/30)

To fix the problem, we should avoid using the user-supplied `query` string as the SQL template, even after performing regex-based replacements. Instead, we should only allow queries of a specific, safe form (e.g., `SELECT * FROM stocks WHERE symbol = '<symbol>'`), extract the symbol value, and use a hardcoded SQL statement with a parameterized placeholder. This ensures that only the intended query is executed and that user input is safely passed as a parameter. Specifically, in the block where `match = re.search(r"where\s+symbol\s*=\s*'([^']+)'", lowered)`, instead of using `re.sub` to modify the user query, we should always use a hardcoded query string and pass the extracted symbol as a parameter. This change should be made in the `exec_user_script` method, replacing lines 251-252 with a safe, hardcoded query.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
